### PR TITLE
Friendly Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
+# Rust build outputs
 /target
 /bin
 /release
+/debug
+
+# Rust artifacts
+*.rs.bk
+*.rlib
+*.prof*
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# Environment
+*.log
+.env*
+
+# Database
 *.db
 *.db-journal
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,252 @@
+#![allow(dead_code)]
+
+pub mod codes;
+pub mod messages;
+
+use codes::ErrorCategory;
+use messages::ErrorCatalog;
+use std::collections::HashMap;
+use tracing::error;
+use uuid::Uuid;
+
+pub trait FriendlyError {
+    fn user_message(&self) -> String;
+    fn troubleshooting(&self) -> Vec<String>;
+    fn is_retryable(&self) -> bool;
+    fn error_code(&self) -> &str;
+    fn category(&self) -> ErrorCategory;
+}
+
+pub fn detect_error_category(error_msg: &str) -> ErrorCategory {
+    let msg_lower = error_msg.to_lowercase();
+
+    if msg_lower.contains("network")
+        || msg_lower.contains("connection")
+        || msg_lower.contains("timeout")
+        || msg_lower.contains("dns")
+        || msg_lower.contains("http")
+        || msg_lower.contains("download")
+    {
+        ErrorCategory::Network
+    } else if msg_lower.contains("file")
+        || msg_lower.contains("directory")
+        || msg_lower.contains("permission")
+        || msg_lower.contains("disk")
+        || msg_lower.contains("path")
+        || msg_lower.contains("not found")
+    {
+        ErrorCategory::FileSystem
+    } else if msg_lower.contains("config")
+        || msg_lower.contains("setting")
+        || msg_lower.contains("invalid")
+        || msg_lower.contains("missing key")
+    {
+        ErrorCategory::Configuration
+    } else if msg_lower.contains("auth")
+        || msg_lower.contains("login")
+        || msg_lower.contains("token")
+        || msg_lower.contains("password")
+        || msg_lower.contains("unauthorized")
+        || msg_lower.contains("permission denied")
+    {
+        ErrorCategory::Authentication
+    } else if msg_lower.contains("archive")
+        || msg_lower.contains("zip")
+        || msg_lower.contains("rar")
+        || msg_lower.contains("7z")
+        || msg_lower.contains("bsa")
+        || msg_lower.contains("corrupt")
+    {
+        ErrorCategory::Archive
+    } else if msg_lower.contains("install")
+        || msg_lower.contains("installing")
+        || msg_lower.contains("installation")
+        || msg_lower.contains("space")
+    {
+        ErrorCategory::Installation
+    } else {
+        ErrorCategory::General
+    }
+}
+
+pub fn get_default_troubleshooting(category: &ErrorCategory) -> Vec<String> {
+    match category {
+        ErrorCategory::Network => vec![
+            "Check your internet connection".to_string(),
+            "Try again later if the server may be down".to_string(),
+            "Verify the address is correct".to_string(),
+        ],
+        ErrorCategory::FileSystem => vec![
+            "Verify the file path is correct".to_string(),
+            "Check file permissions with: ls -la".to_string(),
+            "Ensure the disk has enough space".to_string(),
+        ],
+        ErrorCategory::Configuration => vec![
+            "Check the configuration file for errors".to_string(),
+            "Verify all required settings are present".to_string(),
+            "Try using default configuration".to_string(),
+        ],
+        ErrorCategory::Authentication => vec![
+            "Verify your credentials are correct".to_string(),
+            "Check if your account is active".to_string(),
+            "Try logging in again".to_string(),
+        ],
+        ErrorCategory::Archive => vec![
+            "Verify the archive file is not corrupted".to_string(),
+            "Try downloading the file again".to_string(),
+            "Check if the format is supported".to_string(),
+        ],
+        ErrorCategory::Installation => vec![
+            "Ensure sufficient disk space is available".to_string(),
+            "Close any programs that may be using the target files".to_string(),
+            "Try running as administrator".to_string(),
+        ],
+        ErrorCategory::General => vec![
+            "Try running the command again".to_string(),
+            "Check the logs for more details".to_string(),
+            "Report this issue if it persists".to_string(),
+        ],
+    }
+}
+
+pub fn format_anyhow_error(error: &anyhow::Error, verbose: bool) -> (String, i32) {
+    let error_msg = error.to_string();
+    let category = detect_error_category(&error_msg);
+    let troubleshooting = get_default_troubleshooting(&category);
+    let exit_code = category.exit_code();
+    let reference_id = Uuid::new_v4().to_string();
+
+    error!(
+        error_category = %category.as_str(),
+        is_retryable = false,
+        reference_id = %reference_id,
+        "Error occurred: {}",
+        error_msg
+    );
+
+    let mut output = String::new();
+
+    output.push_str(&format!("[ERROR] {}\n\n", error_msg));
+
+    for step in troubleshooting {
+        output.push_str(&format!("  → {}\n", step));
+    }
+
+    output.push('\n');
+    output.push_str(&format!("Reference ID: {}", reference_id));
+
+    if verbose {
+        output.push_str(&format!("\nTechnical details: {:?}", error));
+    }
+
+    (output, exit_code)
+}
+
+pub struct ErrorFormatter {
+    verbose: bool,
+    catalog: ErrorCatalog,
+    code_map: HashMap<String, String>,
+}
+
+impl ErrorFormatter {
+    pub fn new() -> Self {
+        let catalog = ErrorCatalog::default();
+        let code_map = HashMap::new();
+        Self {
+            verbose: false,
+            catalog,
+            code_map,
+        }
+    }
+
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    pub fn with_catalog(mut self, catalog: ErrorCatalog) -> Self {
+        self.catalog = catalog;
+        self.code_map = self
+            .catalog
+            .messages
+            .iter()
+            .map(|m| (m.error_code.clone(), m.user_message.clone()))
+            .collect();
+        self
+    }
+
+    pub fn format_error<E: FriendlyError>(&self, error: &E) -> String {
+        let reference_id = Uuid::new_v4().to_string();
+
+        error!(
+            error_code = %error.error_code(),
+            category = %error.category().as_str(),
+            is_retryable = error.is_retryable(),
+            reference_id = %reference_id,
+            "Error occurred"
+        );
+
+        let mut output = String::new();
+
+        output.push_str(&format!("[ERROR] {}\n\n", error.user_message()));
+
+        if !error.troubleshooting().is_empty() {
+            for step in error.troubleshooting() {
+                output.push_str(&format!("  → {}\n", step));
+            }
+            output.push('\n');
+        }
+
+        if error.is_retryable() {
+            output.push_str("This error may be temporary. Try running the command again.\n\n");
+        }
+
+        output.push_str(&format!("Reference ID: {}", reference_id));
+
+        if self.verbose {
+            output.push_str(&format!("\nTechnical details: {}", error.error_code()));
+        }
+
+        output
+    }
+}
+
+impl Default for ErrorFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_formatter_basic() {
+        let formatter = ErrorFormatter::new();
+        struct TestError;
+        impl FriendlyError for TestError {
+            fn user_message(&self) -> String {
+                "Test error occurred".to_string()
+            }
+            fn troubleshooting(&self) -> Vec<String> {
+                vec!["Check the logs".to_string()]
+            }
+            fn is_retryable(&self) -> bool {
+                false
+            }
+            fn error_code(&self) -> &str {
+                "TEST_ERROR"
+            }
+            fn category(&self) -> ErrorCategory {
+                ErrorCategory::General
+            }
+        }
+
+        let formatted = formatter.format_error(&TestError);
+        assert!(formatted.contains("[ERROR]"));
+        assert!(formatted.contains("Test error occurred"));
+        assert!(formatted.contains("→ Check the logs"));
+        assert!(formatted.contains("Reference ID:"));
+    }
+}

--- a/src/error/codes.rs
+++ b/src/error/codes.rs
@@ -1,0 +1,69 @@
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorCode {
+    pub category: String,
+    pub code: String,
+    pub exit_code: i32,
+}
+
+impl ErrorCode {
+    pub fn new(category: &str, code: &str, exit_code: i32) -> Self {
+        Self {
+            category: category.to_string(),
+            code: code.to_string(),
+            exit_code,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ErrorCategory {
+    Network,
+    FileSystem,
+    Configuration,
+    Authentication,
+    Archive,
+    Installation,
+    General,
+}
+
+impl ErrorCategory {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorCategory::Network => "network",
+            ErrorCategory::FileSystem => "filesystem",
+            ErrorCategory::Configuration => "config",
+            ErrorCategory::Authentication => "auth",
+            ErrorCategory::Archive => "archive",
+            ErrorCategory::Installation => "installation",
+            ErrorCategory::General => "general",
+        }
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            ErrorCategory::Network => 3,
+            ErrorCategory::FileSystem => 4,
+            ErrorCategory::Configuration => 2,
+            ErrorCategory::Authentication => 1,
+            ErrorCategory::Archive => 5,
+            ErrorCategory::Installation => 6,
+            ErrorCategory::General => 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_category_exit_codes() {
+        assert_eq!(ErrorCategory::Network.exit_code(), 3);
+        assert_eq!(ErrorCategory::FileSystem.exit_code(), 4);
+        assert_eq!(ErrorCategory::Configuration.exit_code(), 2);
+    }
+}

--- a/src/error/messages.en.json
+++ b/src/error/messages.en.json
@@ -1,0 +1,156 @@
+{
+  "version": "1.0.0",
+  "language": "en",
+  "messages": [
+    {
+      "errorCode": "NETWORK_CONNECTION_FAILED",
+      "userMessage": "Unable to connect to the server",
+      "troubleshooting": [
+        "Check your internet connection",
+        "Verify the server address is correct",
+        "Try again later if the server may be down"
+      ],
+      "isRetryable": true
+    },
+    {
+      "errorCode": "NETWORK_TIMEOUT",
+      "userMessage": "The request took too long to complete",
+      "troubleshooting": [
+        "Check your internet connection speed",
+        "Try again - this may be a temporary issue",
+        "If the problem persists, the server may be busy"
+      ],
+      "isRetryable": true
+    },
+    {
+      "errorCode": "NETWORK_DNS_ERROR",
+      "userMessage": "Could not find the server address",
+      "troubleshooting": [
+        "Check that the URL is spelled correctly",
+        "Verify your DNS settings are correct",
+        "Try using a different DNS server"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "FS_FILE_NOT_FOUND",
+      "userMessage": "The requested file could not be found",
+      "troubleshooting": [
+        "Verify the file path is correct",
+        "Check if the file was moved or deleted",
+        "Use 'ls' to verify the file exists"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "FS_PERMISSION_DENIED",
+      "userMessage": "You don't have permission to access this file or folder",
+      "troubleshooting": [
+        "Check file permissions with: ls -la",
+        "Verify you have read/write access to the location",
+        "Try running with elevated permissions if needed"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "FS_DISK_FULL",
+      "userMessage": "Not enough disk space available",
+      "troubleshooting": [
+        "Free up space on your disk",
+        "Delete temporary files or old installations",
+        "Choose a different location with more space"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "CONFIG_INVALID",
+      "userMessage": "The configuration file contains invalid settings",
+      "troubleshooting": [
+        "Check the configuration file for typos",
+        "Verify all required settings are present",
+        "Use the default configuration as a reference"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "CONFIG_MISSING_KEY",
+      "userMessage": "A required configuration setting is missing",
+      "troubleshooting": [
+        "Add the missing key to your configuration file",
+        "Check the documentation for required settings",
+        "Use 'clf3 init' to create a new configuration"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "AUTH_LOGIN_FAILED",
+      "userMessage": "Login failed - incorrect username or password",
+      "troubleshooting": [
+        "Verify your username and password are correct",
+        "Check if your account is locked",
+        "Reset your password if you've forgotten it"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "AUTH_TOKEN_EXPIRED",
+      "userMessage": "Your session has expired",
+      "troubleshooting": [
+        "Log in again to start a new session",
+        "Check if your account is still active",
+        "Contact support if the problem persists"
+      ],
+      "isRetryable": true
+    },
+    {
+      "errorCode": "ARCHIVE_CORRUPT",
+      "userMessage": "The archive file appears to be damaged",
+      "troubleshooting": [
+        "Download the file again",
+        "Verify the file checksum if available",
+        "Try extracting with a different tool"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "ARCHIVE_UNSUPPORTED",
+      "userMessage": "This archive format is not supported",
+      "troubleshooting": [
+        "Verify the file is a supported archive format",
+        "Check the documentation for supported formats",
+        "Convert the archive to a supported format"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "INSTALL_DISK_SPACE",
+      "userMessage": "Not enough space to complete installation",
+      "troubleshooting": [
+        "Free up at least the required amount of space",
+        "Choose a different installation location",
+        "Remove unused programs or files"
+      ],
+      "isRetryable": false
+    },
+    {
+      "errorCode": "INSTALL_FILE_LOCKED",
+      "userMessage": "A file is in use and cannot be modified",
+      "troubleshooting": [
+        "Close any programs that may be using the file",
+        "Restart your computer if necessary",
+        "Try again once the file is available"
+      ],
+      "isRetryable": true
+    },
+    {
+      "errorCode": "GENERAL_UNKNOWN",
+      "userMessage": "An unexpected error occurred",
+      "troubleshooting": [
+        "Try running the command again",
+        "Check the logs for more details",
+        "Report this issue if it persists"
+      ],
+      "isRetryable": true
+    }
+  ]
+}

--- a/src/error/messages.rs
+++ b/src/error/messages.rs
@@ -1,0 +1,54 @@
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorMessage {
+    pub error_code: String,
+    pub user_message: String,
+    #[serde(default)]
+    pub troubleshooting: Vec<String>,
+    #[serde(default, rename = "isRetryable")]
+    pub is_retryable: bool,
+    #[serde(default, rename = "referenceId")]
+    pub reference_id: Option<String>,
+}
+
+impl ErrorMessage {
+    pub fn new(error_code: &str, user_message: &str) -> Self {
+        Self {
+            error_code: error_code.to_string(),
+            user_message: user_message.to_string(),
+            troubleshooting: Vec::new(),
+            is_retryable: false,
+            reference_id: None,
+        }
+    }
+
+    pub fn with_troubleshooting(mut self, steps: Vec<String>) -> Self {
+        self.troubleshooting = steps;
+        self
+    }
+
+    pub fn retryable(mut self) -> Self {
+        self.is_retryable = true;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorCatalog {
+    pub version: String,
+    pub language: String,
+    pub messages: Vec<ErrorMessage>,
+}
+
+impl Default for ErrorCatalog {
+    fn default() -> Self {
+        Self {
+            version: "1.0.0".to_string(),
+            language: "en".to_string(),
+            messages: Vec::new(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod archive;
 pub mod bsa;
 pub mod downloaders;
+pub mod error;
 pub mod game_finder;
 pub mod gpu;
 pub mod gui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod archive;
 mod bsa;
 mod downloaders;
+mod error;
 mod hash;
 mod installer;
 mod modlist;
@@ -128,7 +129,15 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(e) = run().await {
+        let (message, exit_code) = error::format_anyhow_error(&e, std::env::var("RUST_LOG").is_ok());
+        eprintln!("{}", message);
+        std::process::exit(exit_code);
+    }
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     // Set up file logging (always enabled) next to the executable

--- a/tests/unit/test_error_messages.rs
+++ b/tests/unit/test_error_messages.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+mod tests {
+    use clf3::error::codes::{ErrorCategory, ErrorCode};
+
+    #[test]
+    fn test_error_code_creation() {
+        let code = ErrorCode::new("network", "CONNECTION_FAILED", 3);
+        assert_eq!(code.category, "network");
+        assert_eq!(code.code, "CONNECTION_FAILED");
+        assert_eq!(code.exit_code, 3);
+    }
+
+    #[test]
+    fn test_error_category_exit_codes() {
+        assert_eq!(ErrorCategory::Network.exit_code(), 3);
+        assert_eq!(ErrorCategory::FileSystem.exit_code(), 4);
+        assert_eq!(ErrorCategory::Configuration.exit_code(), 2);
+        assert_eq!(ErrorCategory::Authentication.exit_code(), 1);
+        assert_eq!(ErrorCategory::Archive.exit_code(), 5);
+        assert_eq!(ErrorCategory::Installation.exit_code(), 6);
+        assert_eq!(ErrorCategory::General.exit_code(), 1);
+    }
+}


### PR DESCRIPTION
1. **Error Module** (`src/error.rs`)
   - `FriendlyError` trait for custom error types
   - `ErrorFormatter` for CLI output
   - `format_anyhow_error()` - converts anyhow errors to friendly format
   - Auto-detects error category from error messages
   - Provides contextual troubleshooting steps
   - Generates reference IDs for support

2. **Exit Codes** - Based on error category:
   - 1: General
   - 2: Configuration
   - 3: Network
   - 4: File System
   - 5: Archive
   - 6: Installation

3. **Message Catalog** - 15 error messages covering all categories